### PR TITLE
Add nameChanged handler

### DIFF
--- a/core-localstorage.html
+++ b/core-localstorage.html
@@ -72,15 +72,14 @@ triggered only when value is a different instance.
      */
     autoSaveDisabled: false,
     
-    attached: function() {
-      // wait for bindings are all setup
-      this.async('load');
-    },
-    
     valueChanged: function() {
       if (this.loaded && !this.autoSaveDisabled) {
         this.save();
       }
+    },
+
+    nameChanged: function() {
+      this.load();
     },
     
     load: function() {


### PR DESCRIPTION
The `nameChanged` handler leads to the expected behavior if the `name` attribute changes, in that it will attempt to load the `value` corresponding to the `localStorage` cache with the key `name`.

Since `nameChanged` is fired when the `name` attribute is initially set, it shouldn't be necessary to call `load` within the `attached` handler anymore. (At least I don't think it is.)
