### PR TITLE
Allow removal from localStorage

### DIFF
--- a/core-localstorage.html
+++ b/core-localstorage.html
@@ -119,8 +119,16 @@ triggered only when value is a different instance.
     save: function() {
       var v = this.useRaw ? this.value : JSON.stringify(this.value);
       localStorage.setItem(this.name, v);
-    }
+    },
     
+    /** 
+     * Removes the key from localStorage.
+     *
+     * @method remove
+     */
+    remove: function() {
+        localStorage.removeItem(this.name);
+    }
   });
 
 </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -46,10 +46,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
         
-        test('aything' function () {
-            assert.isTrue(true); 
-        });
-        
       test('remove', function(done) {
         storage.value = {'foo': 'bar'};
         storage.remove();

--- a/test/basic.html
+++ b/test/basic.html
@@ -45,6 +45,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
       });
+        
+        test('aything' function () {
+            assert.isTrue(true); 
+        });
+        
+      test('remove', function(done) {
+        storage.value = {'foo': 'bar'};
+        storage.remove();
+        asyncPlatformFlush(function() {
+            var v = window.localStorage.getItem(storage.name);
+            assert.isNull(v);
+            done();
+        });
+      });
 
     });
 

--- a/test/raw.html
+++ b/test/raw.html
@@ -43,6 +43,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
       });
+        
+      test('remove', function(done) {
+        var m = 'remove me';
+        storage.value = m;
+        storage.remove();
+        asyncPlatformFlush(function () {
+            var v = window.localStorage.getItem(storage.name); 
+            assert.isNull(v);
+            done();
+        });
+      });
 
     });
 

--- a/test/value-binding.html
+++ b/test/value-binding.html
@@ -69,7 +69,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
       });
-
+        
+      test('remove', function(done) {
+        xtest.value = { hello: 'worlds' };
+        xtest.$.localStorage.remove();
+        asyncPlatformFlush(function () {
+            assert.isNull(xtest.value);
+            done();
+        });
+      });
     });
     
   </script>


### PR DESCRIPTION
I think it would be useful to have a remove function, as I would like to perform all local storage operations through this element, but currently I find myself switching between calling `this.$.localStorageElem.save()` and `localStorage.removeItem('myKey')` which is kind of messy and a problem for testing.
