### PR TITLE
Allow chrome storage api

### DIFF
--- a/core-localstorage.html
+++ b/core-localstorage.html
@@ -94,8 +94,6 @@ triggered only when value is a different instance.
     },
 
     onAfterLoad: function(v) {
-      console.log("v is ");
-      console.log(v);
       if (this.useRaw) {
         this.value = v;
       } else {
@@ -132,8 +130,6 @@ triggered only when value is a different instance.
       var chromeStorage;
       chromeStorage = chrome.storage[this.useChrome];
       chromeStorage.get([this.name], function(items) {
-        console.log("Getting " + this.name + ":");
-        console.log(items);
         var v = null;
         if(items[this.name]) {
           v = items[this.name];
@@ -143,12 +139,24 @@ triggered only when value is a different instance.
     },
     
     load: function() {
-      console.log("The name is " + this.name);
       if(this.useChrome === null) {
         this.localStorageLoad();
       } else {
         this.chromeStorageLoad();
       }
+    },
+
+    localStorageSave: function(v) {
+      localStorage.setItem(this.name, v);
+    },
+
+    chromeStorageSave: function(v) {
+      var chromeStorage;
+      chromeStorage = chrome.storage[this.useChrome];
+      var nameValue = {};
+      nameValue[this.name] = v;
+      chromeStorage.set(nameValue, function() { 
+      }.bind(this));
     },
 
     /** 
@@ -158,7 +166,11 @@ triggered only when value is a different instance.
      */
     save: function() {
       var v = this.useRaw ? this.value : JSON.stringify(this.value);
-      localStorage.setItem(this.name, v);
+      if(this.useChrome == null) {
+        this.localStorageSave(v);
+      } else {
+        this.chromeStorageSave(v);
+      }
     }
     
   });


### PR DESCRIPTION
When creating a Chrome app, obviously one should use `chrome.storage.local` or `chrome.storage.sync`. To enable one to use `core-localstorage` on a Chrome app, there should be an option allowing the user to choose which api to use.

This PR includes an attribute `useChrome`, which by default is left as null - allowing normal usage of localStorage.  If `useChrome` is `local`, it will use `chrome.storage.local`.  If `sync`, it will use `chrome.storage.sync`.
